### PR TITLE
Add a status field to xnet groups

### DIFF
--- a/htdocs/css/xnet.css
+++ b/htdocs/css/xnet.css
@@ -372,6 +372,7 @@ td.oval2 {
 
 .oval a, .oval2 a { color: #d0c198; }
 .oval a.has_site { color: white; }
+.oval a.grp_inactive, .oval2 a.grp_inactive { font-style:italic; }
 .jone a { color: #FF9; }
 .rouje a { color: #D88; }
 .jone a.has_site { color: #FE0; }

--- a/htdocs/css/xnet.css
+++ b/htdocs/css/xnet.css
@@ -322,6 +322,10 @@ table#liste td.liste a:hover, table#liste td.listec a:hover {
     background: #d0c198;
 }
 
+table#liste td.liste a.grp_inactive {
+    font-style: italic;
+}
+
 #wikitext {
     text-align: justify;
     font-size: 90%;

--- a/modules/lists/lists.inc.php
+++ b/modules/lists/lists.inc.php
@@ -38,7 +38,7 @@ function list_sort_owners($emails, $tri_promo = true)
             'user' => $u,
             'profile' => null,
             'email' => $u->forlifeEmail());
-        $seen[] = $u->forlifeEmail();
+        $seen[] = strtolower($u->forlifeEmail());
     }
 
     $pf = new ProfileFilter(new UFC_Email($emails));
@@ -51,6 +51,7 @@ function list_sort_owners($emails, $tri_promo = true)
     }
 
     foreach ($emails as $email) {
+        $email = strtolower($email);
         if (!in_array($email, $seen)) {
             $seen[] = $email;
             $members[$email] = array('user' => null, 'profile' => null,

--- a/modules/xnet.php
+++ b/modules/xnet.php
@@ -150,37 +150,39 @@ class XnetModule extends PLModule
         $page->setType('plan');
 
         $res = XDB::iterator(
-                'SELECT  dom.id, dom.nom as domnom, groups.diminutif, groups.nom
+                'SELECT  dom.id, dom.nom as domnom, groups.diminutif, groups.nom, groups.status
                    FROM  group_dom AS dom
              INNER JOIN  groups ON dom.id = groups.dom
                   WHERE  FIND_IN_SET("GroupesX", dom.cat) AND FIND_IN_SET("GroupesX", groups.cat)
-               ORDER BY  dom.nom, groups.nom');
+                         AND groups.status IN ("active", "inactive")
+               ORDER BY  dom.nom, groups.status, groups.nom');
         $groupesx = array();
         while ($tmp = $res->next()) { $groupesx[$tmp['id']][] = $tmp; }
         $page->assign('groupesx', $groupesx);
 
         $res = XDB::iterator(
-                'SELECT  dom.id, dom.nom as domnom, groups.diminutif, groups.nom
+                'SELECT  dom.id, dom.nom as domnom, groups.diminutif, groups.nom, groups.status
                    FROM  group_dom AS dom
              INNER JOIN  groups ON dom.id = groups.dom
                   WHERE  FIND_IN_SET("Binets", dom.cat) AND FIND_IN_SET("Binets", groups.cat)
-               ORDER BY  dom.nom, groups.nom');
+                         AND groups.status IN ("active", "inactive")
+               ORDER BY  dom.nom, groups.status, groups.nom');
         $binets = array();
         while ($tmp = $res->next()) { $binets[$tmp['id']][] = $tmp; }
         $page->assign('binets', $binets);
 
         $res = XDB::iterator(
-                'SELECT  diminutif, nom
+                'SELECT  diminutif, nom, status
                    FROM  groups
-                  WHERE  cat LIKE "%Promotions%"
-               ORDER BY  diminutif');
+                  WHERE  cat LIKE "%Promotions%" AND status IN ("active", "inactive")
+               ORDER BY  status, diminutif');
         $page->assign('promos', $res);
 
         $res = XDB::iterator(
-                'SELECT  diminutif, nom
+                'SELECT  diminutif, nom, status
                    FROM  groups
-                  WHERE  FIND_IN_SET("Institutions", cat)
-               ORDER BY  diminutif');
+                  WHERE  FIND_IN_SET("Institutions", cat) AND status IN ("active", "inactive")
+               ORDER BY  status, diminutif');
         $page->assign('inst', $res);
     }
 

--- a/modules/xnet.php
+++ b/modules/xnet.php
@@ -211,16 +211,18 @@ class XnetModule extends PLModule
         $page->assign('doms', $doms);
 
         if (empty($doms)) {
-            $res = XDB::query("SELECT  diminutif, nom, site
+            $res = XDB::query("SELECT  diminutif, nom, site, status
                                  FROM  groups
                                 WHERE  FIND_IN_SET({?}, cat)
-                                ORDER  BY nom", $cat);
+                                       AND status IN ('active', 'inactive')
+                                ORDER  BY status, nom", $cat);
             $page->assign('gps', $res->fetchAllAssoc());
         } elseif (!is_null($dom)) {
-            $res = XDB::query("SELECT  diminutif, nom, site
+            $res = XDB::query("SELECT  diminutif, nom, site, status
                                  FROM  groups
                                 WHERE  FIND_IN_SET({?}, cat) AND dom={?}
-                             ORDER BY  nom", $cat, $dom);
+                                       AND status IN ('active', 'inactive')
+                             ORDER BY  status,nom", $cat, $dom);
             $page->assign('gps', $res->fetchAllAssoc());
         }
 

--- a/modules/xnet.php
+++ b/modules/xnet.php
@@ -203,30 +203,40 @@ class XnetModule extends PLModule
         $page->assign('cat', $cat);
         $page->assign('dom', $dom);
 
-        $res  = XDB::query("SELECT  id,nom
-                              FROM  group_dom
-                             WHERE  FIND_IN_SET({?}, cat)
-                          ORDER BY  nom", $cat);
-        $doms = $res->fetchAllAssoc();
-        $page->assign('doms', $doms);
+        if ($cat == 'deads') {
+            // Show dead groups
+            $res = XDB::query("SELECT  diminutif, nom, site, status
+                                 FROM  groups
+                                WHERE  status = 'dead'
+                                ORDER  BY nom", $cat);
+            $page->assign('doms', array());
+            $page->assign('gps', $res->fetchAllAssoc());
+        } else {
+            $res  = XDB::query("SELECT  id,nom
+                                  FROM  group_dom
+                                 WHERE  FIND_IN_SET({?}, cat)
+                              ORDER BY  nom", $cat);
+            $doms = $res->fetchAllAssoc();
+            $page->assign('doms', $doms);
 
-        if (empty($doms)) {
-            $res = XDB::query("SELECT  diminutif, nom, site, status
-                                 FROM  groups
-                                WHERE  FIND_IN_SET({?}, cat)
-                                       AND status IN ('active', 'inactive')
-                                ORDER  BY status, nom", $cat);
-            $page->assign('gps', $res->fetchAllAssoc());
-        } elseif (!is_null($dom)) {
-            $res = XDB::query("SELECT  diminutif, nom, site, status
-                                 FROM  groups
-                                WHERE  FIND_IN_SET({?}, cat) AND dom={?}
-                                       AND status IN ('active', 'inactive')
-                             ORDER BY  status,nom", $cat, $dom);
-            $page->assign('gps', $res->fetchAllAssoc());
+            if (empty($doms)) {
+                $res = XDB::query("SELECT  diminutif, nom, site, status
+                                     FROM  groups
+                                    WHERE  FIND_IN_SET({?}, cat)
+                                           AND status IN ('active', 'inactive')
+                                    ORDER  BY status, nom", $cat);
+                $page->assign('gps', $res->fetchAllAssoc());
+            } elseif (!is_null($dom)) {
+                $res = XDB::query("SELECT  diminutif, nom, site, status
+                                     FROM  groups
+                                    WHERE  FIND_IN_SET({?}, cat) AND dom={?}
+                                           AND status IN ('active', 'inactive')
+                                 ORDER BY  status,nom", $cat, $dom);
+                $page->assign('gps', $res->fetchAllAssoc());
+            }
+
+            $page->setType($cat);
         }
-
-        $page->setType($cat);
     }
 
     function handler_autologin($page)

--- a/modules/xnetgrp.php
+++ b/modules/xnetgrp.php
@@ -246,6 +246,7 @@ class XnetGrpModule extends PLModule
                     $page->assign('notif_unsub', Post::i('notif_unsub'));
                     $page->assign('descr', Post::t('descr'));
                     $page->assign('disable_mails', Post::b('disable_mails'));
+                    $page->assign('status', Post::v('status'));
                     $page->assign('error', $error);
                     return;
                 }
@@ -262,7 +263,8 @@ class XnetGrpModule extends PLModule
                              descr={?}, site={?}, mail={?}, resp={?},
                              forum={?}, mail_domain={?}, ax={?}, axDate = {?}, pub={?},
                              sub_url={?}, inscriptible={?}, unsub_url={?},
-                             flags = {?}, welcome_msg = {?}, disable_mails = {?}
+                             flags = {?}, welcome_msg = {?}, disable_mails = {?},
+                             status = {?}
                       WHERE  id={?}",
                       Post::v('nom'), Post::v('diminutif'),
                       Post::v('cat'), (Post::i('dom') == 0) ? null : Post::i('dom'),
@@ -272,7 +274,7 @@ class XnetGrpModule extends PLModule
                       Post::has('ax'), $axDate, Post::v('pub'),
                       Post::v('sub_url'), Post::v('inscriptible'),
                       Post::v('unsub_url'), $flags, Post::t('welcome_msg'),
-                      Post::b('disable_mails'),
+                      Post::b('disable_mails'), Post::v('status'),
                       $globals->asso('id'));
                 if (Post::v('mail_domain')) {
                     XDB::execute('INSERT IGNORE INTO  email_virtual_domains (name)
@@ -288,13 +290,15 @@ class XnetGrpModule extends PLModule
                     "UPDATE  groups
                         SET  descr={?}, site={?}, mail={?}, resp={?},
                              forum={?}, pub= {?}, sub_url={?},
-                             unsub_url = {?}, flags = {?}, welcome_msg = {?}
+                             unsub_url = {?}, flags = {?}, welcome_msg = {?},
+                             status = {?}
                       WHERE  id={?}",
                       Post::v('descr'), $site,
                       Post::v('mail'), Post::v('resp'),
                       Post::v('forum'), Post::v('pub'),
                       Post::v('sub_url'), Post::v('unsub_url'),
                       $flags, Post::t('welcome_msg'),
+                      Post::v('status'),
                       $globals->asso('id'));
             }
 
@@ -350,6 +354,7 @@ class XnetGrpModule extends PLModule
         $page->assign('notif_unsub', $globals->asso('notif_unsub'));
         $page->assign('notify_all', $globals->asso('notify_all'));
         $page->assign('disable_mails', $globals->asso('disable_mails'));
+        $page->assign('status', $globals->asso('status'));
     }
 
     function handler_mail($page)

--- a/templates/xnet/groupes.tpl
+++ b/templates/xnet/groupes.tpl
@@ -22,6 +22,7 @@
 
 {include file="xnet/include/descr.tpl"}
 
+{assign var="has_inactive" value=false}
 <table id="content" cellspacing="0" cellpadding="4">
   <tr>
     <td style="vertical-align: top">
@@ -49,7 +50,12 @@
         <tr>
         {/if}
           <td class="oval{if $doms}2{/if} {if $cat eq 'promotions'}{if $g.diminutif is odd}jone{else}rouje{/if}{/if}">
-            <a href="{$g.diminutif}/" {if $g.site}class="has_site"{/if}>{$g.nom}</a>
+          {if $g.status eq 'inactive'}
+            <a href="{$g.diminutif}/" class="grp_inactive{if $g.site} has_site{/if}" title="Groupe inactif">{$g.nom}&nbsp;*</a>
+            {assign var="has_inactive" value=true}
+          {else}
+            <a href="{$g.diminutif}/" {if $g.site} has_site{/if}">{$g.nom}</a>
+          {/if}
           </td>
         {if !$doms && $i is even && $smarty.foreach.all.last}<td></td>{/if}
         {if $doms || $i is odd || $smarty.foreach.all.last}
@@ -61,5 +67,11 @@
     </td>
   </tr>
 </table>
+
+{if $has_inactive}
+<p class="descr">
+(*) Groupe inactif
+</p>
+{/if}
 
 {* vim:set et sw=2 sts=2 sws=2 fenc=utf-8: *}

--- a/templates/xnet/groupes.tpl
+++ b/templates/xnet/groupes.tpl
@@ -30,6 +30,7 @@
       <div class="cat {if $cat eq 'binets'}sel{/if}"><a href="groups/binets">Binets</a></div>
       <div class="cat {if $cat eq 'institutions'}sel{/if}"><a href="groups/institutions">Institutions</a></div>
       <div class="cat {if $cat eq 'promotions'}sel{/if}"><a href="groups/promotions">Promotions</a></div>
+      <div class="cat {if $cat eq 'deads'}sel{/if}"><a href="groups/deads">Groupes archivés</a></div>
     </td>
 
     {if $doms}

--- a/templates/xnet/include/descr.tpl
+++ b/templates/xnet/include/descr.tpl
@@ -67,6 +67,18 @@ de ces promotions d'organiser des repas promos, de faire partager des souvenirs 
 se retrouver sur internet&hellip; En voici des exemples&nbsp;:
 </p>
 
+{elseif $cat eq 'deads'}
+
+<p class="descr">
+Au fil des années, de nouveaux groupes se créent et d'autres disparaissent. Lorsqu'il est déterminé
+qu'un groupe devient inactif, il est d'abord marqué comme tel dans la liste des groupes et reste
+accessible dans les listes par domaine. Certains groupes inactifs ont particulièrement peu de
+chance d'intéresser de nouvelles bonnes volontés, mais garder l'historique des événements et des
+messages des listes de diffusion peut être important. Ces groupes deviennent alors archivés, sont
+retirés des listes des domaines et catégories auxquelles ils appartiennent, et sont enumérés sur
+cette page.
+</p>
+
 {/if}
 
 {* vim:set et sw=2 sts=2 sws=2 fenc=utf-8: *}

--- a/templates/xnet/plan.tpl
+++ b/templates/xnet/plan.tpl
@@ -32,7 +32,11 @@
             {foreach from=$groupesx key=id item=dom}
             <a class="cat" href="groups/groupesx/{$id}">{$dom[0].domnom}</a>
             {foreach from=$dom item=g}
-            <a href="{$g.diminutif}/">{$g.nom}</a>
+              {if $g.status eq 'inactive'}
+                <a class="grp_inactive" href="{$g.diminutif}/" title="Groupe inactif">{$g.nom}&nbsp;*</a>
+              {else}
+                <a href="{$g.diminutif}/">{$g.nom}</a>
+              {/if}
             {/foreach}
             {/foreach}
           </td>
@@ -50,7 +54,11 @@
             {foreach from=$binets key=id item=dom}
             <a class="cat" href="groups/binets/{$id}">{$dom[0].domnom}</a>
             {foreach from=$dom item=g}
-            <a href="{$g.diminutif}/">{$g.nom}</a>
+              {if $g.status eq 'inactive'}
+                <a class="grp_inactive" href="{$g.diminutif}/" title="Groupe inactif">{$g.nom}&nbsp;*</a>
+              {else}
+                <a href="{$g.diminutif}/">{$g.nom}</a>
+              {/if}
             {/foreach}
             {/foreach}
           </td>
@@ -66,7 +74,11 @@
         <tr>
           <td class="listec">
             {iterate from=$promos item=g}
-            <a href="{$g.diminutif}/">{$g.nom}</a>
+              {if $g.status eq 'inactive'}
+                <a class="grp_inactive" href="{$g.diminutif}/" title="Groupe inactif">{$g.nom}&nbsp;*</a>
+              {else}
+                <a href="{$g.diminutif}/">{$g.nom}</a>
+              {/if}
             {/iterate}
           </td>
         </tr>
@@ -81,7 +93,11 @@
         <tr>
           <td class="listec">
             {iterate from=$inst item=g}
-            <a href="{$g.diminutif}/">{$g.nom}</a>
+              {if $g.status eq 'inactive'}
+                <a class="grp_inactive" href="{$g.diminutif}/" title="Groupe inactif">{$g.nom}&nbsp;*</a>
+              {else}
+                <a href="{$g.diminutif}/">{$g.nom}</a>
+              {/if}
             {/iterate}
           </td>
         </tr>
@@ -89,5 +105,9 @@
     </td>
   </tr>
 </table>
+
+<p class="descr">
+(*) Groupe inactif
+</p>
 
 {* vim:set et sw=2 sts=2 sws=2 fenc=utf-8: *}

--- a/templates/xnet/plan.tpl
+++ b/templates/xnet/plan.tpl
@@ -109,5 +109,9 @@
 <p class="descr">
 (*) Groupe inactif
 </p>
+<p class="descr">
+Les groupes archivés n'apparaissent pas sur cette page. Pour les trouver, il faut consulter
+<a href="groups/deads">la liste des groupes archivés</a>.
+</p>
 
 {* vim:set et sw=2 sts=2 sws=2 fenc=utf-8: *}

--- a/templates/xnetgrp/edit.tpl
+++ b/templates/xnetgrp/edit.tpl
@@ -249,6 +249,18 @@
         prévenir les animateurs lors de la désinscription d'un membre</label>
       </td>
     </tr>
+    <tr>
+      <td class="titre">
+        État du groupe&nbsp;:
+      </td>
+      <td>
+        <select name="status">
+          <option value="active" {if $status eq 'active'}selected="selected"{/if}>Actif</option>
+          <option value="inactive" {if $status eq 'inactive'}selected="selected"{/if}>Inactif (visible sur la page "tous les groupes")</option>
+          <option value="dead" {if $status eq 'dead'}selected="selected"{/if}>Mort (absent de la page "tous les groupes")</option>
+        </select>
+      </td>
+    </tr>
   </table>
 
   <div class="center">

--- a/upgrade/1.1.15/02_add_group_status.sql
+++ b/upgrade/1.1.15/02_add_group_status.sql
@@ -1,0 +1,5 @@
+-- A group can be active, inactive (still appear in the list of groups) or dead (put in another page)
+-- The order matters, as it is used to order groups
+ALTER TABLE groups ADD COLUMN status SET('active', 'inactive', 'dead') NOT NULL DEFAULT 'active';
+
+-- vim:set syntax=mysql:


### PR DESCRIPTION
These commits add a status field to xnet groups, with 3 possible values: active, inactive (but still listed) and dead (and archived). The admins of a group can change the state of the group, and the UI listing groups has been updated accordingly.
