### PR TITLE
Make existence of other mailing lists explicit

### DIFF
--- a/templates/lists/index.tpl
+++ b/templates/lists/index.tpl
@@ -112,7 +112,7 @@ thématique particulière.
 <h1>Listes de diffusion publiques auxquelles tu peux t'inscrire</h1>
 
 <p>
-Les listes de diffusion publiques sont visibles par tous les X inscrits à Polytechnique.org.
+Les listes de diffusion publiques sont visibles par tous les X inscrits à Polytechnique.org. Des listes de diffusion destinées aux Groupes X sont par ailleurs disponibles sur <a href="https://www.polytechnique.net/plan">polytechnique.net</a>.
 </p>
 
 {if $public|@count}


### PR DESCRIPTION
Ne sachant pas comment développer en local, je n'ai pas pu tester cette PR. Par contre, elle m'a semblé nécessaire pour un novice qui arrive sur cette page : il n'est pas évident que d'autres ML sont accessibles sur x.net si on se contente de lire la page.
