### PR TITLE
mailinglist: Add 'sudo' mode.

### DIFF
--- a/configs/platal.ini
+++ b/configs/platal.ini
@@ -296,6 +296,14 @@ max_mail_per_min = 400
 ; Domain where mailing list emails are redirected.
 redirect_domain = ""
 
+; $globals->lists->system_login
+; Login used by crons to connect to the MMList daemon
+system_login = "platal"
+
+; $globals->lists->system_password
+; Password used by crons to connect to the MMList daemon
+system_password = ""
+
 
 ; The mail section contains parameters used to interacts with email routing
 [Mail]


### PR DESCRIPTION
This allows a system account (e.g cron) to connect on behalf of a user.
The MailingList operations are still performed with the permissions of
that user; it only allows bypassing the authentication.

Rationale: some users have no defined password (if it was compromised,
for instance)

Technically, the system will login as
<su_login>+<real_login>:<su_password>
