### PR TITLE
Fixes geoloc module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 
 # $Id: Makefile,v 1.5 2004/11/25 20:18:39 x99laine Exp $
 ################################################################################
+#Commit reference of https://github.com/googlemaps/js-marker-clusterer for script & image download
+MAPS_MARKER_CLUSTERER_VERSION=dc326b9b9234ce964861eb35b416a6be1ca7d7cf
+
 # definitions
 
 VERSNUM := $(shell grep VERSION ChangeLog | head -1 | sed -e "s/VERSION //;s/ .*//")
@@ -251,23 +254,20 @@ $(JSTREE_PATH):
 ##
 maps: htdocs/javascript/markerclusterer.js htdocs/images/m1.png htdocs/images/m2.png htdocs/images/m3.png htdocs/images/m4.png htdocs/images/m5.png
 
-## Try and use taged version asap (from http://google-maps-utility-library-v3.googlecode.com/svn/tags/markerclusterer/...).
-## Force to use https to retrieve images
+## Download markerclusterer source and images (from https://github.com/googlemaps/js-marker-clusterer)
 htdocs/javascript/markerclusterer.js:
-	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/src/markerclusterer.js' -O $@.tmp || ($(RM) $@.tmp; false)
-	sed 's,http\(://google-maps-utility-library-v3.googlecode.com\),https\1,g' < $@.tmp > $@
-	$(RM) $@.tmp
-
+	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/src/markerclusterer.js' -O $@
 htdocs/images/m1.png:
-	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m1.png' -O $@
+	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m1.png' -O $@
 htdocs/images/m2.png:
-	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m2.png' -O $@
+	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m2.png' -O $@
 htdocs/images/m3.png:
-	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m3.png' -O $@
+	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m3.png' -O $@
 htdocs/images/m4.png:
-	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m4.png' -O $@
+	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m4.png' -O $@
 htdocs/images/m5.png:
-	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m5.png' -O $@
+	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m5.png' -O $@
+
 
 ##
 ## Raven-js

--- a/Makefile
+++ b/Makefile
@@ -249,14 +249,25 @@ $(JSTREE_PATH):
 ##
 ## Maps auxiliary scripts
 ##
-maps: htdocs/javascript/markerclusterer.js
+maps: htdocs/javascript/markerclusterer.js htdocs/images/m1.png htdocs/images/m2.png htdocs/images/m3.png htdocs/images/m4.png htdocs/images/m5.png
 
 ## Try and use taged version asap (from http://google-maps-utility-library-v3.googlecode.com/svn/tags/markerclusterer/...).
 ## Force to use https to retrieve images
 htdocs/javascript/markerclusterer.js:
-	wget 'http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/src/markerclusterer_compiled.js?r=308' -O $@.tmp -q || ($(RM) $@.tmp; false)
+	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/src/markerclusterer.js' -O $@.tmp || ($(RM) $@.tmp; false)
 	sed 's,http\(://google-maps-utility-library-v3.googlecode.com\),https\1,g' < $@.tmp > $@
 	$(RM) $@.tmp
+
+htdocs/images/m1.png:
+	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m1.png' -O $@
+htdocs/images/m2.png:
+	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m2.png' -O $@
+htdocs/images/m3.png:
+	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m3.png' -O $@
+htdocs/images/m4.png:
+	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m4.png' -O $@
+htdocs/images/m5.png:
+	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m5.png' -O $@
 
 ##
 ## Raven-js

--- a/Makefile
+++ b/Makefile
@@ -255,18 +255,24 @@ $(JSTREE_PATH):
 maps: htdocs/javascript/markerclusterer.js htdocs/images/m1.png htdocs/images/m2.png htdocs/images/m3.png htdocs/images/m4.png htdocs/images/m5.png
 
 ## Download markerclusterer source and images (from https://github.com/googlemaps/js-marker-clusterer)
+htdocs/javascript/markerclusterer.js: DOWNLOAD_SRC=https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/src/markerclusterer.js
 htdocs/javascript/markerclusterer.js:
-	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/src/markerclusterer.js' -O $@
+	$(download)
+htdocs/images/m1.png: DOWNLOAD_SRC=https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m1.png
 htdocs/images/m1.png:
-	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m1.png' -O $@
+	$(download)
+htdocs/images/m2.png: DOWNLOAD_SRC=https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m2.png
 htdocs/images/m2.png:
-	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m2.png' -O $@
+	$(download)
+htdocs/images/m3.png: DOWNLOAD_SRC=https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m3.png
 htdocs/images/m3.png:
-	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m3.png' -O $@
+	$(download)
+htdocs/images/m4.png: DOWNLOAD_SRC=https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m4.png
 htdocs/images/m4.png:
-	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m4.png' -O $@
+	$(download)
+htdocs/images/m5.png: DOWNLOAD_SRC=https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m5.png
 htdocs/images/m5.png:
-	wget 'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/$(MAPS_MARKER_CLUSTERER_VERSION)/images/m5.png' -O $@
+	$(download)
 
 
 ##

--- a/configs/platal.ini
+++ b/configs/platal.ini
@@ -271,6 +271,11 @@ api_version = ""
 ; Language to be used in maps.
 language = ""
 
+; $globals->maps->api_key
+; [Not necessary in prod] a valid api key
+api_key = ""
+
+
 ; The lists section contains parameters used to interact with mailman.
 [Lists]
 

--- a/configs/platal.ini
+++ b/configs/platal.ini
@@ -272,7 +272,8 @@ api_version = ""
 language = ""
 
 ; $globals->maps->api_key
-; [Not necessary in prod] a valid api key
+; A Google API key that can be optained at https://console.developers.google.com/apis/credentials
+; In production, this can be left empty as it seems whitelisted by Google
 api_key = ""
 
 

--- a/htdocs/images/.gitignore
+++ b/htdocs/images/.gitignore
@@ -2,3 +2,8 @@
 /banana
 # ignore jstree related stuff
 /jstree.png
+m1.png
+m2.png
+m3.png
+m4.png
+m5.png

--- a/htdocs/javascript/maps.js
+++ b/htdocs/javascript/maps.js
@@ -24,9 +24,11 @@
 function map_initialize(baseUrl)
 {
     var myOptions = {
-        zoom: 1,
-        center: new google.maps.LatLng(0, 0),
-        mapTypeId: google.maps.MapTypeId.ROADMAP
+        zoom: 5,
+        center: new google.maps.LatLng(48, 2),
+        mapTypeId: google.maps.MapTypeId.ROADMAP,
+        fullscreenControl: true,
+        streetViewControl: false
     };
     var map = new google.maps.Map($('#map_canvas').get(0), myOptions);
 

--- a/htdocs/javascript/maps.js
+++ b/htdocs/javascript/maps.js
@@ -30,8 +30,7 @@ function map_initialize(baseUrl)
     };
     var map = new google.maps.Map($('#map_canvas').get(0), myOptions);
 
-    $.xget(window.location.href, {ajax: true}, function(json_data) {
-        var data = jQuery.parseJSON(json_data);
+    $.xgetJSON(window.location.href, {ajax: true}, function(data) {
         var dots = data.data;
         var count = dots.length;
         var info_window = new google.maps.InfoWindow({});

--- a/htdocs/javascript/maps.js
+++ b/htdocs/javascript/maps.js
@@ -21,7 +21,7 @@
 // http://code.google.com/apis/maps/documentation/javascript/
 // http://code.google.com/p/google-maps-utility-library-v3/wiki/Libraries
 
-function map_initialize()
+function map_initialize(baseUrl)
 {
     var myOptions = {
         zoom: 1,
@@ -69,6 +69,7 @@ function map_initialize()
             });
             markers.push(marker);
         }
+        MarkerClusterer.prototype.MARKER_CLUSTER_IMAGE_PATH_ = baseUrl + "/images/m"
         var mc = new MarkerClusterer(map, markers, {'averageCenter': true});
     });
 }

--- a/modules/geoloc.php
+++ b/modules/geoloc.php
@@ -33,7 +33,10 @@ class GeolocModule extends PLModule
     {
         global $globals;
         $page->changeTpl('geoloc/index.tpl');
-        $map_url = $globals->maps->dynamic_map . '?&sensor=false&v=' . $globals->maps->api_version . '&language=' . $globals->maps->language;
+        $map_url = $globals->maps->dynamic_map . '?v=' . $globals->maps->api_version . '&language=' . $globals->maps->language;
+        if ($globals->maps->api_key) {
+            $map_url .= '&key=' . $globals->maps->api_key;
+        }
         $page->addJsLink($map_url, false);
         $page->addJsLink('maps.js');
         $page->addJsLink('markerclusterer.js');

--- a/templates/geoloc/index.tpl
+++ b/templates/geoloc/index.tpl
@@ -23,7 +23,7 @@
 <div id="map_canvas" style="width: 100%; height: 600px"></div>
 
 <script type="text/javascript">
-  map_initialize();
+  map_initialize('{$globals->baseurl}');
 </script>
 
 {* vim:set et sw=2 sts=2 sws=2 fenc=utf-8: *}


### PR DESCRIPTION
This PR allows two things:
- Makes geoloc work in dev, where an API key is necessary. It is unclear why it is not required by google in prod, probably historic whitelisting.
- Updates markercluster provision (including images) to use google's new repo, and make it work correctly in dev. This fixes the current issue where clusters have no image on the map, only a plain number.

Note that, ideally, we would like the markercluster color to match the embedded markers, but that seems hard to do without forking markercluster itself.