### PR TITLE
Don't notify end users deathdate update.

### DIFF
--- a/bin/cron/profile_modification.php
+++ b/bin/cron/profile_modification.php
@@ -45,7 +45,7 @@ if ($res->total() > 0) {
     $modifications = array();
     $modifications[] = array(
         'full_name' => $values['full_name'],
-        'field'     => $values['field'],
+        'field'     => Profile::field_display($values['field']),
         'oldText'   => $values['oldText'],
         'newText'   => $values['newText'],
     );
@@ -69,7 +69,7 @@ if ($res->total() > 0) {
         $hrpid = $values['hrpid'];
         $modifications[] = array(
             'full_name' => $values['full_name'],
-            'field'     => $values['field'],
+            'field'     => Profile::field_display($values['field']),
             'oldText'   => $values['oldText'],
             'newText'   => $values['newText'],
         );

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -1422,6 +1422,17 @@ class Profile implements PlExportable
             return sprintf('%04u%04u', 1900 + $year, $rank);
         }
     }
+
+    public static function field_display($field_name)
+    {
+        if (array_key_exists($field_name, Profile::$descriptions)) {
+            return Profile::$descriptions[$field_name];
+        } else {
+            // Return the raw field_name, as legacy updates in DB used to store the field_display
+            // instead of its name.
+            return $field_name;
+        }
+    }
 }
 
 

--- a/modules/profile/page.inc.php
+++ b/modules/profile/page.inc.php
@@ -311,7 +311,7 @@ abstract class ProfilePage implements PlWizardPage
                                        VALUES  ({?}, {?}, {?}, {?}, {?}, {?}, NOW())
                       ON DUPLICATE KEY UPDATE  uid = VALUES(uid), oldText = IF(VALUES(type) != type, VALUES(oldText), oldText),
                                                newText = VALUES(newText), type = VALUES(type), timestamp = NOW()',
-                                 $this->pid(), $user->id(), Profile::$descriptions[$field], $values[0], $values[1],
+                                 $this->pid(), $user->id(), $field, $values[0], $values[1],
                                  ($owner->id() == $user->id()) ? 'self' : 'third_party');
                 }
             }

--- a/templates/admin/profile.tpl
+++ b/templates/admin/profile.tpl
@@ -47,7 +47,7 @@
     {iterate item=update from=$updates}
     <tr class="{cycle values="impair,pair"}">
       <td>{$update.directory_name}</td>
-      <td class="center">{$update.field|wordwrap:80:'<br />'}</td>
+      <td class="center">{$update.fields_display|wordwrap:80:'<br />'}</td>
       <td class="center">
         <a href="profile/{$update.hrpid}" class="popup2">{icon name=user_suit title="Voir le profil"}</a>
         <a href="profile/edit/{$update.hrpid}">{icon name=user_edit title="Éditer le profil"}</a>


### PR DESCRIPTION
The code tried to account for this; however, at some point in time, the
content of the 'field' column in 'profile_modification' was updated to
hold the field's display name instead of its code.
This change prevented the actual security code to work properly.

This commit will change the database storage to use a field's codename
instead of its display name.