### PR TITLE
Use the right French word to describe password hashing

### DIFF
--- a/templates/platal/password.success.tpl
+++ b/templates/platal/password.success.tpl
@@ -29,8 +29,9 @@
 <strong>Mot de passe enregistré le {$smarty.now|date_format}</strong>
 </p>
 <p>
-  <strong>Attention&nbsp;!</strong> Il est crypté irréversiblement,
-  donc <strong>non récupérable</strong>. Pour retrouver un accès au site
+  <strong>Attention&nbsp;!</strong> Le mot de passe est transformé par une
+  opération cryptographique irréversible avant d'être enregistré. Il n'est donc
+  <strong>pas récupérable</strong>. Pour retrouver un accès au site
   consécutivement à une perte de mot de passe, la procédure
   est longue et laborieuse&hellip;
 </p>

--- a/templates/platal/tmpPWD.success.tpl
+++ b/templates/platal/tmpPWD.success.tpl
@@ -26,9 +26,10 @@
 <strong>Mot de passe enregistré le {$smarty.now|date_format}</strong>
 </p>
 <p>
-  Cette procédure n'est pas sécurisée. Ton mot de passe est certes crypté, mais le
-  certificat envoyé par mail permet à toute personne pouvant lire ton email (qui n'est
-  pas crypté), de changer ton mot de passe. C'est pourquoi, dans ton intérêt, il est
+  Cette procédure n'est pas sécurisée. Ton mot de passe est certes protégé par
+  une opération cryptographique irréversible, mais le certificat envoyé par
+  mail permet à toute personne pouvant lire ton email (qui n'est pas chiffré),
+  de changer ton mot de passe. C'est pourquoi, dans ton intérêt, il est
   préférable que tu ne perdes pas ton mot de passe&nbsp;!!!
 </p>
 {* vim:set et sw=2 sts=2 sws=2 fenc=utf-8: *}


### PR DESCRIPTION
In French, "crypter" can mean to put into a crypt, which may be found in
some churches. The right word would be for example "chiffrer" for
messages and "hacher" or "obtenir un condensat/une empreinte" for
passwords.

Write messages which do not use "crypter" and which non-technical people
can still understand.