### PR TITLE
Fix email address in profile modification email

### DIFF
--- a/classes/profile.php
+++ b/classes/profile.php
@@ -118,6 +118,8 @@ class Profile implements PlExportable
 
     const FETCH_ALL          = 0x007FFF; // OR of FETCH_*
 
+    const EXAMPLE_EMAIL = 'new@example.org'; // email used in profile email management
+
     static public $descriptions = array(
         'search_names'    => 'Noms',
         'nationality1'    => 'Nationalité',

--- a/modules/email.php
+++ b/modules/email.php
@@ -277,7 +277,7 @@ class EmailModule extends PLModule
             if (Env::v('emailop') == "ajouter" && Env::has('email')) {
                 $error_email = false;
                 $new_email = Env::v('email');
-                if ($new_email == "new@example.org") {
+                if ($new_email == Profile::EXAMPLE_EMAIL) {
                     $new_email = Env::v('email_new');
                 }
                 $result = $redirect->add_email($new_email);

--- a/modules/profile/general.inc.php
+++ b/modules/profile/general.inc.php
@@ -363,14 +363,14 @@ class ProfileSettingEmailDirectory implements ProfileSetting
         $success = true;
         if (!is_null($value)) {
             $email_stripped = strtolower(trim($value));
-            if ((!isvalid_email($email_stripped)) && ($email_stripped) && ($page->values['email_directory'] == "new@example.org")) {
+            if ((!isvalid_email($email_stripped)) && ($email_stripped) && ($page->values['email_directory'] == Profile::EXAMPLE_EMAIL)) {
                 $p->assign('email_error', '1');
                 $p->assign('email_directory_error', $email_stripped);
                 $p->trigError('Adresse Email invalide');
                 $success = false;
             } else {
                 $p->assign('email_error', '0');
-                if ($page->values['email_directory'] == 'new@example.org') {
+                if ($page->values['email_directory'] == Profile::EXAMPLE_EMAIL) {
                     // Update the values so that the form gets handled as if
                     // the new email address was in email_directory
                     $page->values['email_directory'] = $email_stripped;
@@ -729,7 +729,7 @@ class ProfilePageGeneral extends ProfilePage
                 $this->values['nationality3'] = NULL;
             }
 
-            $new_email = ($this->values['email_directory'] == "new@example.org") ?
+            $new_email = ($this->values['email_directory'] == Profile::EXAMPLE_EMAIL) ?
                 $this->values['email_directory_new'] : $this->values['email_directory'];
             if ($new_email == "") {
                 $new_email = NULL;

--- a/modules/profile/general.inc.php
+++ b/modules/profile/general.inc.php
@@ -370,6 +370,11 @@ class ProfileSettingEmailDirectory implements ProfileSetting
                 $success = false;
             } else {
                 $p->assign('email_error', '0');
+                if ($page->values['email_directory'] == 'new@example.org') {
+                    // Update the values so that the form gets handled as if
+                    // the new email address was in email_directory
+                    $page->values['email_directory'] = $email_stripped;
+                }
             }
         }
         return $value;
@@ -628,7 +633,7 @@ class ProfilePageGeneral extends ProfilePage
                                         = $this->settings['profile_title']
                                         = null;
         $this->settings['email_directory'] = new ProfileSettingEmail();
-        $this->settings['email_directory_new'] = new ProfileSettingEmailDirectory();
+        $this->settings['email_directory_new'] = new ProfileSettingEmailDirectory(); // This field needs to be processed after email_directory
         $this->settings['tels'] = new ProfileSettingPhones();
         $this->settings['edus'] = new ProfileSettingEdu();
         $this->settings['main_edus'] = new ProfileSettingMainEdu();

--- a/modules/profile/jobs.inc.php
+++ b/modules/profile/jobs.inc.php
@@ -133,7 +133,7 @@ class ProfileSettingJob implements ProfileSetting
 
     private function cleanJob(ProfilePage $page, $jobid, array &$job, &$success, $job_level)
     {
-        if ($job['w_email'] == "new@example.org") {
+        if ($job['w_email'] == Profile::EXAMPLE_EMAIL) {
             $job['w_email'] = $job['w_email_new'];
         }
         foreach ($this->checks as $obj=>&$fields) {

--- a/templates/include/emails.combobox.tpl
+++ b/templates/include/emails.combobox.tpl
@@ -47,7 +47,7 @@
       {/if}
       {/foreach}
       <optgroup label="Autres choix">
-        <option value="new@example.org" {if ($val eq '' && !$error && $name eq 'email') || $error}selected="selected"{/if}>Nouvelle adresse email</option>
+        <option value="{#Profile::EXAMPLE_EMAIL#}" {if ($val eq '' && !$error && $name eq 'email') || $error}selected="selected"{/if}>Nouvelle adresse email</option>
         {if $name neq "email"}<option value="" {if $val eq '' && !$error}selected="selected"{/if}>Ne pas mettre d'adresse email</option>{/if}
       </optgroup>
     </select>
@@ -87,7 +87,7 @@
         var i = {/literal}{$i}{literal};
         $('select#combobox' + i).change(function() {
           $('.new' + i).hide();
-          if ($('select#combobox' + i).val() == "new@example.org") {
+          if ($('select#combobox' + i).val() == '{/literal}{#Profile::EXAMPLE_EMAIL#}{literal}') {
             $('.new' + i).show();
           }
         }).change();


### PR DESCRIPTION
When an administrator updates the email which is displayed in the
directory to an address which is neither a main address nor a
redirection one, the notification email which is currently sent tells
that the address has been modified to "new@example.org". This is the
value of option "New email address" in the profile modification page,
not the real value of the address which got added to the database.

Fix this by modifying the value of field "email_directory" in the
profile form for general information when field "email_directory_new"
contains a valid email address.