### PR TITLE
Rename "mentors" to "référents"

### DIFF
--- a/modules/profile.php
+++ b/modules/profile.php
@@ -337,7 +337,7 @@ class ProfileModule extends PLModule
         }
         $wiz->addPage('ProfilePageDecos', 'Décorations - Medailles', 'deco');
         if ($viewPrivate) {
-            $wiz->addPage('ProfilePageMentor', 'Mentoring', 'mentor');
+            $wiz->addPage('ProfilePageMentor', 'Référents', 'mentor');
         }
         if ($viewPrivate && $profile->isDeltatenEnabled(Profile::DELTATEN_OLD)) {
             $wiz->addPage('ProfilePageDeltaten', 'Opération N N-10', 'deltaten');

--- a/templates/profile/mentor.tpl
+++ b/templates/profile/mentor.tpl
@@ -26,7 +26,7 @@
 </div>
 {if !$expertise || !t($sectors) || !($sectors|@count)}
   <br /><div>
-    <strong>{icon name=error title="Attention"} Attention&nbsp;: pour figurer dans la base de données des mentors, il faut remplir la
+    <strong>{icon name=error title="Attention"} Attention&nbsp;: pour figurer dans la base de données des référents, il faut remplir la
     dernière case en bas de cette page et avoir au moins un secteur d'activité de prédilection.</strong><br />
   </div>
 {/if}
@@ -40,7 +40,7 @@
   notamment internationales sur la base desquels tu seras identifiable depuis
   <a href="referent/search#mentors">la page de recherche d'un conseil professionnel</a>.<br />
 </p>
-<p>Le mentoring est particulièrement important pour les camarades&nbsp;:</p>
+<p>Le renseignement de référents est particulièrement important pour les camarades&nbsp;:</p>
 <ul>
   <li>encore jeunes, qui sont en train de bâtir leur projet professionnel&nbsp;;</li>
   <li>ou bien, plus âgés, qui souhaitent réorienter leur carrière.</li>
@@ -119,7 +119,7 @@
   </tr>
  </table>
 
-<table class="bicol" id="countries_table" style="margin-bottom: 1em" summary="Profil&nbsp;: Mentoring">
+<table class="bicol" id="countries_table" style="margin-bottom: 1em" summary="Profil&nbsp;: Référent">
   <tr>
     <th>
       <div class="flags" style="float: left">
@@ -159,7 +159,7 @@
 
 <script type="text/javascript" src="javascript/jquery.jstree.js"></script>
 
-<table class="bicol" style="margin-bottom: 1em" summary="Profil&nbsp;: Mentoring">
+<table class="bicol" style="margin-bottom: 1em" summary="Profil&nbsp;: Référent">
   <tr>
     <th colspan="2">
       <div class="flags" style="float: left">
@@ -207,7 +207,7 @@
   </tr>
 </table>
 
-<table class="bicol" summary="Profil&nbsp;: Mentoring">
+<table class="bicol" summary="Profil&nbsp;: Référent">
   <tr>
     <th>
       <div class="flags" style="float: left">
@@ -224,7 +224,7 @@
       veux bien que ceux de nos camarades qui seraient intéressés par un
       contact avec toi, en prennent l'initiative. <strong>Il est obligatoire de
       remplir cette dernière case pour apparaître dans la base de données
-      des "Mentors".</strong>
+      des "Référents".</strong>
     </td>
   </tr>
   <tr>

--- a/templates/search/referent.tpl
+++ b/templates/search/referent.tpl
@@ -30,7 +30,7 @@
 <a id="mentors"></a>
 
 <p>
-Actuellement, {$mentors_number} mentors et référents se sont déclarés sur {#globals.core.sitename#}.
+Actuellement, {$mentors_number} référents se sont déclarés sur {#globals.core.sitename#}.
 </p>
 
 {javascript name=jquery.jstree}


### PR DESCRIPTION
Increase the consistency in the words which are used in the community:
"mentors" relates to a program managed by AX's Bureau des Carrières.