### PR TITLE
Really display the title in table icon alt text

### DIFF
--- a/templates/search/adv.form.autocomplete_select.tpl
+++ b/templates/search/adv.form.autocomplete_select.tpl
@@ -27,7 +27,7 @@
     <input name="{$name}_text" type="text" class="autocomplete" size="32" value="{$value_text}" />
     <input name="{$name}" type="hidden" class="autocomplete_target" value="{$value}" />
     <a href="{$name}" class="autocomplete_to_select" title="display" id="{$name}_table">
-      {icon name="table" title=$title}
+      <img src="images/icons/table.gif" alt="{$title}" title="{$title}" />
     </a>
   </td>
 </tr>


### PR DESCRIPTION
Currently on advanced search page, the table icon gets rendered as the
following HTML code:

    <img src="images/icons/table.gif"
    alt="escape_html($this->_tpl_vars['title'])"
    title="escape_html($this->_tpl_vars['title'])">

This is because {icon ...} (implemented in
core/plugins/compiler.icon.php) does not support variable arguments.

Work around this limitation by using the full icon img tag in the Smarty
template.