### PR TITLE
Move the password change page to auth.polytechnique.org

### DIFF
--- a/modules/platal.php
+++ b/modules/platal.php
@@ -247,32 +247,6 @@ class PlatalModule extends PLModule
     {
         global $globals;
 
-        if (Post::has('pwhash') && Post::t('pwhash'))  {
-            S::assert_xsrf_token();
-
-            S::set('password', $password = Post::t('pwhash'));
-            XDB::execute('UPDATE  accounts
-                             SET  password = {?}
-                           WHERE  uid={?}', $password,
-                         S::i('uid'));
-
-            // If GoogleApps is enabled, and the user did choose to use synchronized passwords,
-            // updates the Google Apps password as well.
-            if ($globals->mailstorage->googleapps_domain) {
-                require_once 'googleapps.inc.php';
-                $account = new GoogleAppsAccount(S::user());
-                if ($account->active() && $account->sync_password) {
-                    $account->set_password($password);
-                }
-            }
-
-            S::logger()->log('passwd');
-            Platal::session()->setAccessCookie(true);
-
-            $page->changeTpl('platal/password.success.tpl');
-            $page->run();
-        }
-
         $page->changeTpl('platal/password.tpl');
         $page->setTitle('Mon mot de passe');
         $page->assign('do_auth', 0);

--- a/templates/platal/password.tpl
+++ b/templates/platal/password.tpl
@@ -26,79 +26,8 @@
 </h1>
 
 <p>
-  Le mot de passe doit faire au moins <strong>6 caractères</strong> et comporter deux types de
-  caractères parmi les suivants&nbsp;: lettres minuscules, lettres majuscules, chiffres, caractères spéciaux.
-  Attention au type de clavier que tu utilises (qwerty&nbsp;?) et aux majuscules/minuscules.
+  Le mot de passe du compte Polytechnique.org est maintenant enregistré sur le service d'authentification de Polytechnique.org, <a href="https://auth.polytechnique.org/">auth.polytechnique.org</a>. Pour le modifier, il suffit de se rendre sur <a href="https://auth.polytechnique.org/accounts/password/change/">la page qui y est consacrée</a>.
 </p>
-<p>
-  Pour une sécurité optimale, le mot de passe {if !t($xnet)}{if !t($xnet_reset)} circule de manière chiffrée (https) et{/if}{/if} est stocké chiffré irréversiblement sur nos serveurs.
-</p>
-<br />
-<fieldset style="width: 70%; margin-left: 15%">
-  <legend>{icon name=lock} Saisie du {if !t($xnet)}nouveau {/if}mot de passe</legend>
-  <form action="{$smarty.server.REQUEST_URI}" method="post" id="login">
-  {xsrf_token_field}
-    <table style="width: 100%">
-      <tr>
-        <td class="titre">
-          Mot de passe&nbsp;:
-        </td>
-        <td>
-          <input type="password" size="10" maxlength="256" name="new1" />
-        </td>
-      </tr>
-      <tr>
-        <td class="titre">
-          Confirmation&nbsp;:
-        </td>
-        <td>
-          <input type="password" size="10" maxlength="256" name="new2" />
-        </td>
-      </tr>
-      <tr>
-        <td class="titre">
-          Sécurité
-        </td>
-        <td>
-          {checkpasswd prompt="new1" submit="submitn"}
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <input type="hidden" name="username" value="{$hruid}" />
-          <input type="hidden" name="password" value="" />
-          <input type="hidden" name="domain" value="email" />
-        </td>
-        <td {popup caption='Connexion permanente' width='300' text='Décocher cette case pour que le site oublie ce navigateur.<br />
-          Il est conseillé de décocher la case si cette machine n\'est pas <b>strictement</b> personnelle'} colspan="2">
-          <label><input type="checkbox" name="remember" checked="checked" />
-            Garder l'accès aux services après déconnexion.
-          </label>
-        </td>
-      </tr>
-      <tr>
-        <td colspan="2" class="center">
-          <input type="hidden" name="pwhash" value="" />
-          <input type="submit" value="{if t($xnet)}Créer{else}Changer{/if}" name="submitn" onclick="return hashResponse('new1', 'new2', true, {$do_auth});" />
-        </td>
-      </tr>
-    </table>
-  </form>
-</fieldset>
-
-<form action="{$smarty.server.REQUEST_URI}" method="post" id="loginsub">
-  <div>
-    <input type="hidden" name="challenge" value="{$smarty.session.challenge}" />
-    <input type="hidden" name="username"  value="" />
-    <input type="hidden" name="remember"  value="" />
-    <input type="hidden" name="response"  value="" />
-    <input type="hidden" name="xorpass"   value="" />
-    <input type="hidden" name="domain"    value="" />
-    <input type="hidden" name="auth_type" value="{if t($xnet)}xnet{/if}" />
-    <input type="hidden" name="pwhash"    value="" />
-    {if t($xnet)}<input type="hidden" name="wait" />{/if}
-  </div>
-</form>
 
 {if !t($xnet)}{if !t($xnet_reset)}
 <p>


### PR DESCRIPTION
Some users continue to use it in order to change their passwords, even
though there is no chance for it to work. As the SMTP password is not
yet handled by auth.polytechnique.org, keep the page with a link to the
SMTP password change page, but add a link to auth.polytechnique.org.