### PR TITLE
Raise the maximum length to the TLD to 64

### DIFF
--- a/include/platal.inc.php
+++ b/include/platal.inc.php
@@ -175,7 +175,7 @@ function isvalid_email($email)
     // la rfc2822 authorise les caractères "a-z", "0-9", "!", "#", "$", "%", "&", "'", "*", "+", "-", "/", "=", "?", "^",  `", "{", "|", "}", "~" aussi bien dans la partie locale que dans le domaine.
     // Pour la partie locale, on réduit cet ensemble car il n'est pas utilisé.
     // Pour le domaine, le système DNS limite à [a-z0-9.-], on y ajoute le "_" car il est parfois utilisé.
-    return preg_match("/^[a-z0-9_.'+-]+@[a-z0-9._-]+\.[a-z]{2,6}$/i", $email);
+    return preg_match("/^[a-z0-9_.'+-]+@[a-z0-9._-]+\.[a-z]{2,63}$/i", $email);
 }
 
 function pl_url($path, $query = null, $fragment = null)


### PR DESCRIPTION
A user wants to redirect her emails to an address with the top-level
domain ".solutions". This address is currently considered invalid
because the TLD has more than 6 characters.

Raise the TLD length to something reasonable, like the maximum length of
a DNS label, 63 characters according to section "2.3.4. Size limits" of
RFC 1035 (https://tools.ietf.org/html/rfc1035#section-2.3.4).