### PR TITLE
Auto-activate pending Xnet account on succesful SSO login.

### DIFF
--- a/classes/xorggroupexsession.php
+++ b/classes/xorggroupexsession.php
@@ -49,6 +49,18 @@ class XorgGroupeXSession extends XorgSession
             S::set('loginX', $url);
         }
 
+        if (S::user()->type == 'xnet' && S::user()->state == 'pending') {
+            XDB::startTransaction();
+            XDB::query('UPDATE  accounts
+                           SET  state = \'active\', registration_date = NOW()
+                         WHERE  uid = {?} AND state = \'pending\' AND type = \'xnet\'',
+                       S::user()->id());
+            XDB::query('DELETE FROM  register_pending_xnet
+                              WHERE  uid = {?}',
+                       S::user()->id());
+            XDB::commit();
+        }
+
         return true;
     }
 


### PR DESCRIPTION
This auto-activates any Xnet account successfully login-in from the SSO while it was pending.

The registration logic was copied from https://github.com/Polytechnique-org/platal/blob/f21de68fe470b22e181257a44391ce6514c204ac/modules/platal.php#L482-L490

I am not sure this is the most optimal way to achieve this in terms of number of SQL queries, though.