### PR TITLE
Remove redundant JOIN statement in the SQL query for email aliases

### DIFF
--- a/modules/email.php
+++ b/modules/email.php
@@ -95,8 +95,7 @@ class EmailModule extends PLModule
                                           ((s.type = 'alias_aux') AND d.aliasing = d.id) AS alias
                                     FROM  email_source_account  AS s
                               INNER JOIN  accounts              AS a ON (s.uid = a.uid)
-                              INNER JOIN  email_virtual_domains AS m ON (s.domain = m.id)
-                              INNER JOIN  email_virtual_domains AS d ON (d.aliasing = m.id)
+                              INNER JOIN  email_virtual_domains AS d ON (d.aliasing = s.domain)
                                    WHERE  s.uid = {?}
                                 ORDER BY  !alias, s.email, d.name",
                                  $user->id());


### PR DESCRIPTION
In handler_emails(), the SQL query which fetches all the aliases of a
given user a "INNER JOIN  email_virtual_domains AS m ON (s.domain =
m.id)" was used.

This JOIN is useless, because:
- table "m" is not used anywhere in the request but in another JOIN
  statement, which uses m.id, which is always s.domain by construction
- there always exists an entry for a domain ID in email_virtual_domains
  when aliases targeting the domain exist. So this "INNER JOIN" always
  finds something and never drops any record.

In order to ease code review of changes altering email_virtual_domains
table, drop the useless INNER JOIN statement. This would not introduce
any change.