### PR TITLE
Use S::user() only when it is not null, in session management

### DIFF
--- a/classes/xorggroupexsession.php
+++ b/classes/xorggroupexsession.php
@@ -49,7 +49,7 @@ class XorgGroupeXSession extends XorgSession
             S::set('loginX', $url);
         }
 
-        if (S::user()->type == 'xnet' && S::user()->state == 'pending') {
+        if (S::user() !== null && S::user()->type == 'xnet' && S::user()->state == 'pending') {
             XDB::startTransaction();
             XDB::query('UPDATE  accounts
                            SET  state = \'active\', registration_date = NOW()


### PR DESCRIPTION
PHP warns about trying to get properties from null:

    Notice: Trying to get property of non-object