### PR TITLE
Fix the last step of the user registration process

### DIFF
--- a/classes/xorggroupexsession.php
+++ b/classes/xorggroupexsession.php
@@ -81,6 +81,21 @@ class XorgGroupeXSession extends XorgSession
         return User::getSilentWithValues(null, array('uid' => Get::i('uid')));
     }
 
+    /* Fake an authentication request, to force the authentication of a given user.
+     * This is used for example in the last step of the registration process,
+     * in order to authenticate the user who is registering
+     */
+    public function craftFakeAuthContext($uid, $forlife)
+    {
+        global $globals;
+
+        // Use strings in $_GET
+        Get::set('uid', "$uid");
+        Get::set('forlife', "$forlife");
+        // Compute the fake response to the current session challenge
+        Get::set('auth', md5('1' . S::v('challenge') . $globals->xorgauth->secret . Get::i('uid') . '1'));
+    }
+
     protected function startSessionAs($user, $level) {
         S::kill('loginX');
         S::kill('challenge');

--- a/modules/register.php
+++ b/modules/register.php
@@ -387,7 +387,13 @@ class RegisterModule extends PLModule
 
         // Try to start a session (so the user don't have to log in); we will use
         // the password available in Post:: to authenticate the user.
-        Platal::session()->start(AUTH_PASSWD);
+        // ... but this does not work when using a SSO. Fix this with craftFakeAuthContext
+        Platal::session()->craftFakeAuthContext($uid, $forlife);
+        if (!Platal::session()->start(AUTH_PASSWD)) {
+            $page->trigError("Impossible de démarrer une session. Cela peut être dû à une erreur temporaire. Si cela se reproduit, merci de remonter ce bug par mail à contact@polytechnique.org");
+            S::logger($uid)->log('auth_fail', 'unable to start session (register/end)');
+            return;
+        }
 
         // Add the registration email address as first and only redirection.
         require_once 'emails.inc.php';


### PR DESCRIPTION
The registration process relied on being able to authenticate a user if her password was available in ``$_POST``. This have been broken since the introduction of auth.polytechnique.org SSO.

Fix this by introducing ``craftFakeAuthContext()`` for the specific need of the user registration process.