### PR TITLE
Redirect the end of the registration process to the emails page

### DIFF
--- a/modules/register.php
+++ b/modules/register.php
@@ -570,7 +570,7 @@ class RegisterModule extends PLModule
         // Remove old pending marketing requests for the new user.
         Marketing::clear($uid);
 
-        pl_redirect('profile/edit');
+        pl_redirect('emails');
     }
 }
 


### PR DESCRIPTION
As ``profile/edit`` only shows a warning message advertising the new website, it seems better to redirect users who complete the registration process to the page which shows their email addresses.