### PR TITLE
xnetgrp: Fix duplicate email_virtual_domains.

### DIFF
--- a/modules/xnetgrp.php
+++ b/modules/xnetgrp.php
@@ -282,13 +282,18 @@ class XnetGrpModule extends PLModule
                       Post::b('disable_mails'), Post::v('status'),
                       $globals->asso('id'));
                 if (Post::v('mail_domain')) {
-                    XDB::execute('INSERT IGNORE INTO  email_virtual_domains (name)
-                                              VALUES  ({?})',
-                                 Post::t('mail_domain'));
-                    XDB::execute('UPDATE  email_virtual_domains
-                                     SET  aliasing = id
-                                   WHERE  name = {?}',
-                                 Post::t('mail_domain'));
+                    $count = XDB::fetchOneCell(
+                        'SELECT COUNT(*) FROM email_virtual_domains WHERE name = {?}',
+                        Post::t('mail_domain'));
+                    if ($count == 0) {
+                        XDB::execute('INSERT INTO  email_virtual_domains (name)
+                                                   VALUES  ({?})',
+                                     Post::t('mail_domain'));
+                        XDB::execute('UPDATE  email_virtual_domains
+                                         SET  aliasing = id
+                                       WHERE  name = {?}',
+                                     Post::t('mail_domain'));
+                    }
                 }
             } else {
                 XDB::execute(


### PR DESCRIPTION
The previous code was performing `INSERT IGNORE` into the
email_virtual_domains table: each edit was creating an extra, useless,
identical line.

That wouldn't be an issue if we had proper unicity constraints on the
table; but we don't.