### PR TITLE
Fix duplicated key failure in update_alias_user()

### DIFF
--- a/include/emails.inc.php
+++ b/include/emails.inc.php
@@ -106,10 +106,14 @@ function update_list_alias($email, $former_email, $local_part, $domain, $type = 
 // Updates an email in all aliases (groups and events).
 function update_alias_user($former_email, $new_email)
 {
-    XDB::execute('UPDATE  email_virtual
-                     SET  redirect = {?}
-                   WHERE  redirect = {?} AND (type = \'alias\' OR type = \'event\')',
+    // This request fails to update if the new email is already subscribed to the alias/event
+    XDB::execute('UPDATE IGNORE  email_virtual
+                            SET  redirect = {?}
+                          WHERE  redirect = {?} AND (type = \'alias\' OR type = \'event\')',
                  $new_email, $former_email);
+    XDB::execute('DELETE FROM  email_virtual
+                        WHERE  redirect = {?} AND (type = \'alias\' OR type = \'event\')',
+                 $former_email);
 }
 
 function list_alias_members($local_part, $domain)


### PR DESCRIPTION
When ``update_alias_user()`` adds a redirection email ``$R`` for account ``$A`` and there are events where both ``$R`` and ``$A`` are subscribed, the ``UPDATE`` query fails:

    UPDATE  email_virtual
       SET  redirect = '$A'
     WHERE  redirect = '$R' AND (type = 'alias' OR type = 'event')

    Duplicate entry '16-06-29-absents-95-$A' for key 'PRIMARY'

Fix this by using a SQL form of a ``UPDATE ON DUPLICATE KEY DELETE`` statement (https://leo.steamr.com/2011/09/mysql-update-on-duplicate-key-delete-work-around/).