### PR TITLE
Only show recent AX letters

### DIFF
--- a/modules/newsletter.php
+++ b/modules/newsletter.php
@@ -78,7 +78,9 @@ class NewsletterModule extends PLModule
 
         $page->assign_by_ref('nl', $nl);
         $page->assign('nls', $nl->subscriptionState());
-        $page->assign('nl_list', $nl->listSentIssues(true));
+        // The AX has waaaay too many newsletter to display. Restrict to the recent ones only
+        $only_recent = ($nl->group == 'AX');
+        $page->assign('nl_list', $nl->listSentIssues(true, null, $only_recent));
     }
 
     function handler_nl_show($page, $nid = 'last')
@@ -214,7 +216,9 @@ class NewsletterModule extends PLModule
         }
 
         $page->assign_by_ref('nl', $nl);
-        $page->assign('nl_list', $nl->listAllIssues());
+        // The AX has waaaay too many newsletter to display. Restrict to the recent ones only
+        $only_recent = ($nl->group == 'AX');
+        $page->assign('nl_list', $nl->listAllIssues($only_recent));
     }
 
     function handler_admin_nl_groups($page, $sort = 'id', $order = 'ASC')


### PR DESCRIPTION
There are too many AX letters for the admin pages and it was triggering a 500 error (because of exhausted memory).

The current implementation of newsletter issues listing does not scale at all, but instead of refactoring it in order to reduce the number of SQL statements, introduce a reasonable time limit which speeds up a lot the AX pages.