### PR TITLE
Fix public survey pages

### DIFF
--- a/modules/survey/survey.inc.php
+++ b/modules/survey/survey.inc.php
@@ -91,6 +91,9 @@ class Survey
 
     public function canSeeEarlyResults(User $user)
     {
+        if (empty($user)) {
+            return false;
+        }
         return $user->id() == $this->creator || $user->checkPerms('admin');
     }
     // }}}
@@ -349,7 +352,7 @@ class Survey
         default:
             return null;
         }
-        if (!S::user()->checkPerms(PERMS_USER)) {
+        if (!S::logged() || !S::user()->checkPerms(PERMS_USER)) {
             $where .=  XDB::format(' AND mode = {?}', self::MODE_ALL);
         }
         $sql = 'SELECT id, title, uid, end, mode

--- a/templates/survey/show_root.tpl
+++ b/templates/survey/show_root.tpl
@@ -37,7 +37,7 @@
         <td class="titre">Type de sondage&nbsp;:</td>
         <td>{$survey_modes[$survey.mode]}</td>
       </tr>
-      {if $survey.mode != Survey::MODE_ALL}
+      {if $survey.mode != #Survey::MODE_ALL#}
       <tr>
         <td class="titre">Promotions&nbsp;:</td>
         <td>


### PR DESCRIPTION
Fix `/survey/` pages when they are accessed without authentication. They currently trigger HTTP 500 errors.