### PR TITLE
Change NL submit pages to refer to AX website

### DIFF
--- a/templates/comletter/submit.tpl
+++ b/templates/comletter/submit.tpl
@@ -88,6 +88,7 @@ Il te faut te limiter à 8 lignes de 68 caractères.
 
 <p>
 La procédure de soumission d'articles pour la lettre de la communauté a changé, tu peux la trouver à l'addresse suivante: <a href="https://ax.polytechnique.org/page/proposer-un-article-dans-notre-newsletter">instructions sur le site de l'AX</a>.
+Si la page est vide, connecte-toi d'abord sur le site de l'AX en cliquant sur le bouton «&nbsp;Je me connecte&nbsp;» de <a href="https://ax.polytechnique.org">https://ax.polytechnique.org</a> avant d'aller de nouveau sur <a href="https://ax.polytechnique.org/page/proposer-un-article-dans-notre-newsletter">la page des instructions</a>.
 </p>
 <!--
 <p>

--- a/templates/comletter/submit.tpl
+++ b/templates/comletter/submit.tpl
@@ -87,6 +87,10 @@ Il te faut te limiter à 8 lignes de 68 caractères.
 <h2>Proposer un article</h2>
 
 <p>
+La procédure de soumission d'articles pour la lettre de la communauté a changé, tu peux la trouver à l'addresse suivante: <a href="https://ax.polytechnique.org/page/proposer-un-article-dans-notre-newsletter">instructions sur le site de l'AX</a>.
+</p>
+<!--
+<p>
 Tu peux <a href='comletter/submit#conseils'>lire les conseils de rédaction</a> avant de proposer ton article.
 </p>
 <form action="comletter/submit" method='post'>
@@ -134,8 +138,8 @@ Tu peux <a href='comletter/submit#conseils'>lire les conseils de rédaction</a> 
 </form>
 
 <a id='conseils'></a>
-{include wiki=Xorg.LettreCommunaute}
-
+{* {include wiki=Xorg.LettreCommunaute} *}
+-->
 {/if}
 
 {* vim:set et sw=2 sts=2 sws=2 fenc=utf-8: *}

--- a/templates/newsletter/submit.tpl
+++ b/templates/newsletter/submit.tpl
@@ -89,6 +89,7 @@ Il te faut te limiter à 8 lignes de 68 caractères.
 
 <p>
 La procédure de soumission d'articles pour la lettre mensuelle a changé, tu peux la trouver à l'addresse suivante: <a href="https://ax.polytechnique.org/page/proposer-un-article-dans-notre-newsletter">instructions sur le site de l'AX</a>.
+Si la page est vide, connecte-toi d'abord sur le site de l'AX en cliquant sur le bouton « Je me connecte » de <a href="https://ax.polytechnique.org">https://ax.polytechnique.org</a> avant d'aller de nouveau sur <a href="https://ax.polytechnique.org/page/proposer-un-article-dans-notre-newsletter">la page des instructions</a>.
 </p>
 
 <!--

--- a/templates/newsletter/submit.tpl
+++ b/templates/newsletter/submit.tpl
@@ -88,6 +88,11 @@ Il te faut te limiter à 8 lignes de 68 caractères.
 <h2>Proposer un article</h2>
 
 <p>
+La procédure de soumission d'articles pour la lettre mensuelle a changé, tu peux la trouver à l'addresse suivante: <a href="https://ax.polytechnique.org/page/proposer-un-article-dans-notre-newsletter">instructions sur le site de l'AX</a>.
+</p>
+
+<!--
+<p>
 Tu peux <a href='nl/submit#conseils'>lire les conseils de rédaction</a> avant de proposer ton article.
 </p>
 <form action="nl/submit" method='post'>
@@ -135,7 +140,8 @@ Tu peux <a href='nl/submit#conseils'>lire les conseils de rédaction</a> avant d
 </form>
 
 <a id='conseils'></a>
-{include wiki=Xorg.LettreMensuelle}
+{* {include wiki=Xorg.LettreMensuelle} *}
+-->
 
 {/if}
 


### PR DESCRIPTION
This changes the "submit an article" pages for the monthly and community NL to redirect users to the instructions on the AX website.