### PR TITLE
Loosen access to the "Lost email" page

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@ VERSION 1.1.24                                                       XX XX XXXX
     * Profiles:
         - Display the school id on profiles                                 -XEL
 
+    * Emails:
+        - Open up access to the "lost users" page                           -XEL
+
     * Admin:
         - Improve the help message on AX ID batch edition page              -XEL
 

--- a/modules/email.php
+++ b/modules/email.php
@@ -32,6 +32,7 @@ class EmailModule extends PLModule
             'emails/send'             => $this->make_hook('send',        AUTH_PASSWD, 'mail'),
             'emails/antispam/submit'  => $this->make_hook('submit',      AUTH_COOKIE, 'user'),
             'emails/test'             => $this->make_hook('test',        AUTH_COOKIE, 'mail', NO_AUTH),
+            'emails/lost'             => $this->make_hook('lost',        AUTH_COOKIE, 'user'),
 
             'emails/rewrite/in'       => $this->make_hook('rewrite_in',  AUTH_PUBLIC),
             'emails/rewrite/out'      => $this->make_hook('rewrite_out', AUTH_PUBLIC),


### PR DESCRIPTION
This page is not strictly sensitive; the only risk is that a user uses
said page to find lost users and steal their account — but, having
already an account, they wouldn't gain much more rights.