### PR TITLE
wats4u: Update protocol

### DIFF
--- a/modules/wats4u/sso.inc.php
+++ b/modules/wats4u/sso.inc.php
@@ -152,10 +152,12 @@ function wats4u_sso_v1_build_return_url($user)
     $ax_id = $profile->ax_id;
     $email = $user->forlifeEmail();
     $contributing = 1;  // TODO: Fetch actual data
+    $last_name = $profile->lastName();
+    $first_name = $profile->firstName();
 
     $signature = md5("1" . $challenge . $globals->wats4u->shared_key . $ax_id . "1");
 
-    $cleartext_data = "$challenge\n$ax_id\n$email\n$contributing";
+    $cleartext_data = "$challenge\n$ax_id\n$email\n$contributing\n$last_name\n$first_name";
     $encrypted_data = wats4u_sso_v1_encrypt_data($cleartext_data, $globals->wats4u->shared_key);
     if ($encrypted_data === false) {
         return "";


### PR DESCRIPTION
The Wats4U platform is moving hands (from MeteoJob to AlumnForce).
The new hosting provider has unilateraly modified the authentication
protocol without bumping the version field.

This change adjusts to the new protocol, adding two new fields to the
returned data — ordinary first / last names.